### PR TITLE
Documents config file location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 `distractd`
 
-You will be walked through a few steps to ensure the script can communicate with your receiver. The setup process will also copy an example config file to your home directory.
+You will be walked through a few steps to ensure the script can communicate with your receiver. The setup process will also copy an example config file to your home directory, at `~/.distractinator.conf`.
 
 ### Specifying a logfile: ###
 By default, the log messages will print to stdout. You can specify a logfile location with the --log argument.


### PR DESCRIPTION
Plain and simple: explicitly states the filepath for the INI config file
in the README, so first-time users will know exactly where to look
before even running the program.

Closes #2.