### PR TITLE
Added try/except loop for config creation

### DIFF
--- a/distractinator/Distractinator.py
+++ b/distractinator/Distractinator.py
@@ -101,9 +101,13 @@ class Distractinator:
         hwid = get_hardware_id()
     
         # Write the hwid to the config file
-        config = configparser.ConfigParser()
-        config.add_section('hardware')
-        config.set('hardware', 'device_id', value=hwid)
+        try:
+            config = configparser.ConfigParser()
+            config.add_section('hardware')
+            config.set('hardware', 'device_id', value=hwid)
+        except:
+            self.log.error("Unable to create config file.")
+            raise Exception('Config file was not created')
         with open(desired_location, 'a') as configfile:
             config.write(configfile)
 


### PR DESCRIPTION
If the config process is ended before being completed,  it will create
an empty .conf file. This allows the user to bail out of the setup
incase they have to set permissions or something related.